### PR TITLE
Fix plural forms breakage when FALLBACK is set.

### DIFF
--- a/src/java/org/xnap/commons/i18n/EmptyResourceBundle.java
+++ b/src/java/org/xnap/commons/i18n/EmptyResourceBundle.java
@@ -25,9 +25,8 @@ import java.util.Locale;
 import java.util.ResourceBundle;
 
 /**
- * A <code>ResourceBundle</code> that returns the key as a value.
+ * A GNU-style <code>ResourceBundle</code> that contains no keys.
  *
- * FIXME needs to implement proper plural handling
  * FIXME the bundle needs to have a valid locale for proper sourceCodeLocale handling
  */
 class EmptyResourceBundle extends ResourceBundle
@@ -40,11 +39,12 @@ class EmptyResourceBundle extends ResourceBundle
 	}
 
 	/**
-	 * Returns the key as value.
+	 * Returns the null value. This allows {@link I18n} to handle plural
+	 * forms correctly.
 	 */
-	protected Object handleGetObject(String key) 
+	public Object handleGetObject(String key) 
 	{
-		return key;
+		return null;
 	}
 
 	public Enumeration getKeys() 
@@ -56,7 +56,11 @@ class EmptyResourceBundle extends ResourceBundle
 	{
 		return locale;
 	}
-	
+
+	public ResourceBundle getParent() {
+		return null;
+	}
+
 	private static class EmptyStringEnumeration implements Enumeration
 	{
 

--- a/src/java/org/xnap/commons/i18n/I18n.java
+++ b/src/java/org/xnap/commons/i18n/I18n.java
@@ -313,12 +313,7 @@ public class I18n {
 	 */
 	public final String trn(String text, String pluralText, long n)
 	{
-		try {
-			return trnInternal(bundle, text, pluralText, n);
-		}
-		catch (MissingResourceException e) {
-			return (n == 1) ? text : pluralText;
-		}
+		return trnInternal(bundle, text, pluralText, n);
 	}
 
 	/**
@@ -464,12 +459,23 @@ public class I18n {
 				catch (Exception e) {}
 			}
 			else {
-				return bundle.getString(text);
+				// For a non-GNU ResourceBundle we cannot access 'parent' and
+				// 'handleGetObject', so make a single call to catalog and all
+				// its parent catalogs at once.
+				Object localValue;
+				try {
+					localValue = bundle.getObject(text);
+				}
+				catch (MissingResourceException e) {
+					break;
+				}
+				if (localValue != null)
+					return (String)localValue;
+				break;
 			}
 		}
 		while (bundle != null);
-		throw new MissingResourceException("Can not find resource for key " + text + " in bundle "
-				+ orgBundle.getClass().getName(), orgBundle.getClass().getName(), text);
+		return (n == 1) ? text : pluralText;
 	}
 
 	/**
@@ -514,12 +520,7 @@ public class I18n {
 	 * @since 0.9.5
 	 */
 	public final String trnc(String context, String singularText, String pluralText, long n) {
-		try {
-			return trnInternal(bundle, context + CONTEXT_GLUE + singularText, pluralText, n);
-		}
-		catch (MissingResourceException e) {
-			return (n == 1) ? singularText : pluralText;
-		}
+		return trnInternal(bundle, context + CONTEXT_GLUE + singularText, pluralText, n);
 	}
 
 	/**

--- a/src/test/org/xnap/commons/i18n/EmptyResourceBundleTest.java
+++ b/src/test/org/xnap/commons/i18n/EmptyResourceBundleTest.java
@@ -19,6 +19,8 @@
  */
 package org.xnap.commons.i18n;
 
+import java.util.MissingResourceException;
+
 import junit.framework.TestCase;
 
 /**
@@ -29,8 +31,12 @@ public class EmptyResourceBundleTest extends TestCase {
 	public void test()
 	{
 		EmptyResourceBundle bundle = new EmptyResourceBundle(null);
-		assertEquals("Foo", bundle.getObject("Foo"));
 		assertFalse(bundle.getKeys().hasMoreElements());
+		try {
+			bundle.getObject("Foo");
+			fail("MissingResourceException expected");
+		}
+		catch (MissingResourceException mre) {}
 	}
 
 }

--- a/src/test/org/xnap/commons/i18n/I18nTest.java
+++ b/src/test/org/xnap/commons/i18n/I18nTest.java
@@ -38,6 +38,8 @@ public class I18nTest extends TestCase {
 
 	private I18n i18nEN;
 
+	private I18n i18nEN_EMPTY;
+
 	protected void setUp() throws Exception
 	{
 		try {
@@ -48,6 +50,7 @@ public class I18nTest extends TestCase {
 					"Please make sure you run 'mvn org.xnap.commons:maven-gettext-plugin:dist' before executing tests");
 		}
 		i18nEN = new I18n(BASENAME, Locale.ENGLISH, getClass().getClassLoader());
+		i18nEN_EMPTY = new I18n(new EmptyResourceBundle (Locale.ENGLISH));
 	}
 
 	protected void tearDown() throws Exception
@@ -182,6 +185,12 @@ public class I18nTest extends TestCase {
 				.trn("Foo {1} {2} {3} {0}", "Foos", 1, "foo", "bar", "baz", "boing"));
 		assertEquals("Foo foo bar baz boing", i18nEN
 				.trn("Foo {0} {1} {2} {3}", "Foos", 1, "foo", "bar", "baz", "boing"));
+	}
+
+	public void testTrnEmpty()
+	{
+		assertEquals("Foo", i18nEN_EMPTY.trn("Foo", "Bar", 1));
+		assertEquals("Bar", i18nEN_EMPTY.trn("Foo", "Bar", 2));
 	}
 
 	public void testSetEmptyResources()


### PR DESCRIPTION
The FALLBACK flag causes an EmptyResourceBundle to be used; that class
cannot possibly construct the second (plural) form because it is given
only the singular form as the argument. Only the caller (I18n class) has
access to the plural form argument.
- EmptyResourceBundle.java:
  - Implement GNU methods; this makes it fall into the "GNU" bundle case
    in I18n.trnInternal()
  - handleGetObject(): return null, instead of (singular only) key
- I18n.java:
  - catch and ignore MissingResourceException when looking up
    non-existant keys in non-GNU bundles; this is how the original GNU
    GettextResource class works
  - refactored useless try/catch blocks
- I18nTest.java:
  - add new test for plural forms w/EmptyResourceBundle
- EmptyResourceBundleTest.java:
  - fix test to expect MissingResourcException from getObject()
